### PR TITLE
jupyter root will be the current directory from which wsctl is invoked

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following services are provided in the workspace:
 
 ## Getting Started
 1.  Make a copy of the analytics workspace project\
-Open a terminal window and change to the directory where the workspace is to be created.
+Open a terminal window and change to the directory where the project is to be created.
 ```
 # cd to the directory where the workplace will be created
 git clone https://github.com/datwiz/analytics-workspace.git workspace
@@ -34,9 +34,11 @@ Refer to [Accessing Services](#access) for details on accessing the services.
 
 ## About the workspace
 ### directories
-* `${WORKSPACE_ROOT_DIR}/data/postgresql/data`     postgresql database data
-* `${WORKSPACE_ROOT_DIR}/data/postgresql/pgadmin`  pgadmin config and session data
+* `${SRC_ROOT_DIR}/data/postgresql/data`     postgresql database data
+* `${SRC_ROOT_DIR}/data/postgresql/pgadmin`  pgadmin config and session data
 * `${WORKSPACE_ROOT_DIR}/notebooks`                jupyter notebooks and lab config and notebook data
+
+Notice that the `Jupyter notebook` root directory will be the one from which you invoke `wsctl start`. This means you can always change to another location in your directory tree and invoke `wsctl start` from there, as for example, `~/work/analytics/bin/wsctl start`.
 
 ### docker images
 The docker images are pegged to the version tags current as of 16-Apr-18.  To use different docker

--- a/bin/wsctl
+++ b/bin/wsctl
@@ -27,7 +27,7 @@ esac
 
 ############## set the root directory for the workspace  ##############
 # set the workspace root directory to the parent of the bin directory
-SRC_ROOT_DIR="$(cd "$(dirname "${0}")/../."; pwd -P)"
+export SRC_ROOT_DIR="$(cd "$(dirname "${0}")/../."; pwd -P)"
 # enable override if desired
 export WORKSPACE_ROOT_DIR="${WORKSPACE_ROOT_DIR:-${SRC_ROOT_DIR}}"
 echo "wsctl: using workspace: ${WORKSPACE_ROOT_DIR}"
@@ -35,32 +35,32 @@ echo "wsctl: using username: ${USER}"
 
 ############## ensure required directories exist ##############
 # ensure the postgresql data directory exists
-[ ! -d ${WORKSPACE_ROOT_DIR}/data/postgresql/data ] && install -d ${WORKSPACE_ROOT_DIR}/data/postgresql/data
+[ ! -d ${SRC_ROOT_DIR}/data/postgresql/data ] && install -d ${SRC_ROOT_DIR}/data/postgresql/data
 # ensure the pgadmin data directory exists
-[ ! -d ${WORKSPACE_ROOT_DIR}/data/postgresql/pgadmin ] && install -d ${WORKSPACE_ROOT_DIR}/data/postgresql/pgadmin
+[ ! -d ${SRC_ROOT_DIR}/data/postgresql/pgadmin ] && install -d ${SRC_ROOT_DIR}/data/postgresql/pgadmin
 
 ############## do the work ##############
 case ${action} in
   start)
-    docker-compose -f ${WORKSPACE_ROOT_DIR}/docker-compose.yml up -d
+    docker-compose -f ${SRC_ROOT_DIR}/docker-compose.yml up -d
     echo "wsctl: services started"
     ;;
   stop)
-    docker-compose -f ${WORKSPACE_ROOT_DIR}/docker-compose.yml stop
+    docker-compose -f ${SRC_ROOT_DIR}/docker-compose.yml stop
     echo "wsctl: services stopped"
     ;;
   restart)
-    docker-compose -f ${WORKSPACE_ROOT_DIR}/docker-compose.yml restart
+    docker-compose -f ${SRC_ROOT_DIR}/docker-compose.yml restart
     echo "wsctl: services restarted"
     ;;
   reset)
-    docker-compose -f ${WORKSPACE_ROOT_DIR}/docker-compose.yml down
+    docker-compose -f ${SRC_ROOT_DIR}/docker-compose.yml down
     echo "wsctl: services reset and ready to be started."
     ;;
   status)
-    docker-compose -f ${WORKSPACE_ROOT_DIR}/docker-compose.yml ps
-    svc_cnt=`docker-compose -f ${WORKSPACE_ROOT_DIR}/docker-compose.yml ps -q | wc -l`
-    up_cnt=`docker-compose -f ${WORKSPACE_ROOT_DIR}/docker-compose.yml ps | grep " Up " | wc -l`
+    docker-compose -f ${SRC_ROOT_DIR}/docker-compose.yml ps
+    svc_cnt=`docker-compose -f ${SRC_ROOT_DIR}/docker-compose.yml ps -q | wc -l`
+    up_cnt=`docker-compose -f ${SRC_ROOT_DIR}/docker-compose.yml ps | grep " Up " | wc -l`
     echo "wsctl: $((up_cnt)) of $((svc_cnt)) services running"
     ;;
   *)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       CHOWN_HOME: "yes"
       GRANT_SUDO: "yes"
     volumes:
-    - ${WORKSPACE_ROOT_DIR}/notebooks:/home/${USER}
+    - ${WORKSPACE_ROOT_DIR}:/home/${USER}
     ports:
     - "8888:8888"
 
@@ -24,7 +24,7 @@ services:
       POSTGRES_PASSWORD: "password"
       POSTGRES_DB: "datalab"
     volumes:
-      - ${WORKSPACE_ROOT_DIR}/data/postgresql/data:/var/lib/postgresql/data
+      - ${SRC_ROOT_DIR}/data/postgresql/data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
 
@@ -35,6 +35,6 @@ services:
       PGADMIN_DEFAULT_EMAIL: "${USER}"
       PGADMIN_DEFAULT_PASSWORD: "password"
     volumes:
-    - ${WORKSPACE_ROOT_DIR}/data/postgresql/pgadmin:/var/lib/pgadmin
+    - ${SRC_ROOT_DIR}/data/postgresql/pgadmin:/var/lib/pgadmin
     ports:
       - "8080:80"


### PR DESCRIPTION
Hi, Chris.

This is not the optimal solution, but it works for me. I want to simply use the workspace and all its tools in multiple projects. It is more convenient for me to change the root directory where `Jupyter`'s worskpace will be than to clone this workspace for each new project.

The changes are slight. I just detached `WORKSPACE_ROOT_DIR` from the rest of the services and set it to `$(pwd)`. Jupyter should be the only service that will start from the current directory.